### PR TITLE
refactor (HG-92): 로그인 관련 코드 수정 및 회원 정보 테스트 코드 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,34 +1,46 @@
+// src/App.js
 import React from 'react';
-import { Navigate, Routes, Route } from 'react-router-dom';
+import { Navigate, Routes, Route, useLocation } from 'react-router-dom';
 
 import './assets/css/reset.css';
 import './assets/css/style.css';
+
 import SearchBar from './components/SearchBar';
 import Header from './components/Header';
 import Main from './components/Main';
 import Footer from './components/Footer';
 import Slider from './components/Slider';
 import PrivateRoute from './components/PrivateRoute';
+import ProductList from './components/ProductList';
+import Recommend from './components/Recommend';
 
 import LoginPage from './pages/Login';
-import Signup from './pages/Signup'; // 🔹 소문자 파일 이름 기준 import
-import Product from './pages/Product'; //  상세 페이지
-import Search from './pages/Search'; // 검색 페이지
+import Signup from './pages/Signup';
+import Product from './pages/Product';
+import Search from './pages/Search';
 import CartPage from './pages/Cart';
-import Checkout from './pages/Checkout'; // 결제 페이지
+import Checkout from './pages/Checkout';
+import Alerts from './pages/Alerts';
+
 import MyPageHome    from './pages/mypage/Home';
 import ProfilePage   from './pages/mypage/Profile';
 import OrdersPage    from './pages/mypage/Orders';
 import FavoritesPage from './pages/mypage/Favorites';
-import Alerts from './pages/Alerts';
 
-import { useAuth } from './context/AuthContext';
-import ProductList from './components/ProductList';
+import AdminLogin from './pages/admin/Login';
+import AdminDashboard from './pages/admin/Dashboard';
+import AdminProductList from './pages/admin/products/AdminProductList';
+import AdminProductForm from './pages/admin/products/AdminProductForm';
+import AdminAdList from './pages/admin/ads/AdminAdList';
+import AdminAdForm from './pages/admin/ads/AdminAdForm';
+import AdminAlertList from './pages/admin/alerts/AdminAlertList';
+import AdminAlertForm from './pages/admin/alerts/AdminAlertForm';
 
 import PayApprove from './pages/pay/PayApprove';
 import PayCancel from './pages/pay/PayCancel';
 import PayFail from './pages/pay/PayFail';
-import Recommend from './components/Recommend';
+
+import { useAuth } from './context/AuthContext';
 
 const HomePage = () => (
   <>
@@ -42,13 +54,104 @@ const HomePage = () => (
 );
 
 const App = () => {
+  const location = useLocation();
+  const isAdminRoute = location.pathname.startsWith('/admin');
+
+  // 관리자 전용 접근 가드
+  const RequireAdminAuth = ({ children }) => {
+    const adminId = sessionStorage.getItem('adminId');
+    return adminId ? children : <Navigate to="/admin" replace />;
+  };
   const { user } = useAuth();
 
   return (
     <>
-      <Header element="nexon" />
+      {!isAdminRoute && <Header element="nexon" />}
 
       <Routes>
+        {/* 관리자 페이지 */}
+        <Route path="/admin" element={<AdminLogin />} />
+        <Route
+          path="/admin/dashboard"
+          element={
+            <RequireAdminAuth>
+              <AdminDashboard />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/products"
+          element={
+            <RequireAdminAuth>
+              <AdminProductList />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/products/new"
+          element={
+            <RequireAdminAuth>
+              <AdminProductForm />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/products/:id"
+          element={
+            <RequireAdminAuth>
+              <AdminProductForm />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/ads"
+          element={
+            <RequireAdminAuth>
+              <AdminAdList />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/ads/new"
+          element={
+            <RequireAdminAuth>
+              <AdminAdForm />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/ads/:id"
+          element={
+            <RequireAdminAuth>
+              <AdminAdForm />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/alerts"
+          element={
+            <RequireAdminAuth>
+              <AdminAlertList />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/alerts/new"
+          element={
+            <RequireAdminAuth>
+              <AdminAlertForm />
+            </RequireAdminAuth>
+          }
+        />
+        <Route
+          path="/admin/alerts/:id"
+          element={
+            <RequireAdminAuth>
+              <AdminAlertForm />
+            </RequireAdminAuth>
+          }
+        />
+        
         {/* 메인 */}
         <Route path="/" element={<HomePage />} />
 
@@ -98,6 +201,16 @@ const App = () => {
           element={<PrivateRoute><FavoritesPage /></PrivateRoute>}
         />
 
+        {/* 로그인해야 접근 가능한 Alerts */}
+        <Route
+          path="/alerts"
+          element={
+            <PrivateRoute>
+              <Alerts />
+            </PrivateRoute>
+          }
+        />
+
         <Route
           path="/pay/approve" 
           element={<PayApprove />}
@@ -109,16 +222,6 @@ const App = () => {
         <Route
           path="/pay/fail" 
           element={<PayFail />}
-        />
-
-        {/* 로그인해야 접근 가능한 Alerts */}
-        <Route
-          path="/alerts"
-          element={
-            <PrivateRoute>
-              <Alerts />
-            </PrivateRoute>
-          }
         />
 
         {/* 그 외 모든 경로 */}

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,3 +1,4 @@
+// src/api/auth.js
 import api from './index';
 import axios from 'axios';
 
@@ -5,102 +6,34 @@ const USE_STUB = process.env.REACT_APP_USE_STUB === 'true';
 
 /**
  * 로그인 요청
- * - 실제: { access, refresh } 만 내려옴
- * - 스텁: test/test 계정만 허용
+ * - stub 모드: mockapi 에서 account/password 매칭 후 임의 JWT 생성
+ * - 실제 모드: POST /user/login 으로 { access, refresh } 반환
  */
-// export async function loginRequest(account, password) {
-//   if (USE_STUB) {
-//     return new Promise((resolve, reject) => {
-//       setTimeout(() => {
-//         if (account === 'test' && password === 'test') {
-//           // header.payload.signature
-//           const header  = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
-//           const payload = btoa(JSON.stringify({ user_id: 'test' }));
-//           const fakeToken = `${header}.${payload}.`;
-//           resolve({ access: fakeToken, refresh: fakeToken });
-//         } else {
-//           reject(new Error('Invalid credentials'));
-//         }
-//       }, 200);
-//     });
-//   }
+export async function loginRequest(account, password) {
+  if (USE_STUB) {
+    // mockapi 에서 가입된 유저 목록 조회
+    const users = await axios
+      .get('https://68144d36225ff1af162871b7.mockapi.io/signup')
+      .then(res => res.data);
 
-//   const res = await api.post('/login', { account, password });
-//   return res.data; // { access, refresh }
-// }
-
-// /**
-//  * (필요시) 유저 정보 재조회
-//  */
-// export function getUserInfo(account) {
-//   if (USE_STUB) {
-//     return Promise.resolve({
-//       user_id: 'test'
-//     });
-//   }
-//   return api.get(`/user/${account}`).then(res => res.data);
-// }
-
-// /**
-//  * 회원가입 요청
-//  */
-// export function signupRequest(data) {
-//   if (USE_STUB) {
-//     return Promise.resolve({ success: true });
-//   }
-//   return api.post('/signup', data).then(res => res.data);
-// }
-
-/**
- * 로그인 요청
- * - 실제: mockapi에서 전체 사용자 목록을 가져와서 클라이언트에서 account/password 매칭
- */
-export async function loginRequest(user_id, password) {
-  if (!USE_STUB) {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        if (user_id === 'test' && password === 'test') {
-          const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
-          const payload = btoa(JSON.stringify({ user_id: 'test' }));
-          const fakeToken = `${header}.${payload}.`;
-          resolve({ access: fakeToken, refresh: fakeToken });
-        } else {
-          reject(new Error('Invalid credentials'));
-        }
-      }, 200);
-    });
-  }
-
-  try {
-    const response = await api.get('https://68144d36225ff1af162871b7.mockapi.io/signup'); // 실제 등록된 사용자 목록 조회
-    const users = response.data;
-
-    const user = users.find(u => u.user_id === user_id && u.password === password);
-    console.log("✅ 찾은 유저:", user);
-
+    // account/password가 모두 일치하는 유저 찾기
+    const user = users.find(u => u.user_id === account && u.password === password);
     if (!user) {
       throw new Error('Invalid credentials');
     }
 
-    // 임의 JWT 생성 (학습용)
-    const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+    // 학습용 임의 JWT 생성 (header.payload.)
+    const header  = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
     const payload = btoa(JSON.stringify({ user_id: user.id }));
     const fakeToken = `${header}.${payload}.`;
 
     return { access: fakeToken, refresh: fakeToken };
-  } catch (error) {
-    throw new Error('로그인 실패: ' + error.message);
+  } else {
+    // 실제 백엔드 호출
+    // POST /user/login { account, password } → { access, refresh }
+    const res = await api.post('/user/login', { account, password });
+    return res.data;
   }
-}
-
-/**
- * (필요시) 유저 정보 재조회
- */
-export function getUserInfo(user_id) {
-  if (USE_STUB) {
-    return Promise.resolve({ user_id: 'test' });
-  }
-  return api.get(`/user/${user_id}`).then(res => res.data);
 }
 
 /**

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -1,10 +1,34 @@
 // src/api/profile.js
 import api from './index';
+import axios from 'axios';
 
+const USE_STUB = process.env.REACT_APP_USE_STUB === 'true';
+const MOCK_BASE = 'https://68144d36225ff1af162871b7.mockapi.io';
+
+/**
+ * 프로필 조회
+ * - stub 모드: mockapi의 /signup/:id
+ * - 실제 모드: 백엔드 /user/:id
+ */
 export function fetchProfile(user_id) {
+  if (USE_STUB) {
+    return axios
+      .get(`${MOCK_BASE}/signup/${user_id}`)
+      .then(res => res.data);
+  }
   return api.get(`/user/${user_id}`).then(res => res.data);
 }
 
+/**
+ * 프로필 수정
+ * - stub 모드: mockapi의 /signup/:id 로 PUT
+ * - 실제 모드: 백엔드 /user/:id 로 PUT
+ */
 export function updateProfile(user_id, data) {
+  if (USE_STUB) {
+    return axios
+      .put(`${MOCK_BASE}/signup/${user_id}`, data)
+      .then(res => res.data);
+  }
   return api.put(`/user/${user_id}`, data).then(res => res.data);
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,3 +1,4 @@
+// src/context/AuthContext.jsx
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { getSessionId, clearSession as clearSessionStorage } from '../utils/session';
@@ -11,8 +12,14 @@ const AuthContext = createContext({
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
 
-  const login = ({ user_id }) => {
-    getSessionId(); // 로그인 시점에 세션 발급
+  const login = ({ access, refresh }) => {
+    // 1) 토큰 저장
+    localStorage.setItem('accessToken', access);
+    localStorage.setItem('refreshToken', refresh);
+    // 2) 세션 발급
+    getSessionId();
+    // 3) payload에서 user_id 추출
+    const { user_id } = jwtDecode(access);
     setUser({ user_id });
   };
 
@@ -24,16 +31,15 @@ export function AuthProvider({ children }) {
     window.location.replace('/');
   };
 
+  // 새로고침 후에도 토큰이 유효하면 자동 로그인
   useEffect(() => {
     const access = localStorage.getItem('accessToken');
     if (!access) return;
     try {
       const { user_id, exp } = jwtDecode(access);
-
-      // 만료 시 자동 로그아웃
-      if (Date.now() / 1000 > exp) return logout();
-
-      // user 객체는 { user_id } 형태로 통일
+      if (Date.now() / 1000 > exp) {
+        return logout();
+      }
       setUser({ user_id });
     } catch {
       logout();

--- a/src/hooks/useProfile.js
+++ b/src/hooks/useProfile.js
@@ -3,60 +3,30 @@ import { useState, useEffect } from 'react';
 import { useAuth }             from '../context/AuthContext';
 import { fetchProfile, updateProfile } from '../api/profile';
 
-const USE_STUB = process.env.REACT_APP_USE_STUB === 'true';
-
-// 스텁 데이터
-const PROFILE_STUB = {
-  name:    '홍길동',
-  age:     30,
-  gender:  'M',
-  address: '서울특별시 강남구 테헤란로 123',
-};
-const STORAGE_KEY = 'profile_stub';
-
 export function useProfile() {
   const { user } = useAuth();
   const user_id  = user?.user_id;
   const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!user_id) return;
-
-    if (USE_STUB) {
-      // stub 모드: 미리 정의된 데이터로 세팅
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved) {
-        setProfile(JSON.parse(saved));
-      } else {
-        setProfile(PROFILE_STUB);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(PROFILE_STUB));
-      }
-    } else {
-      // 실제 API 호출
-      fetchProfile(user_id)
-        .then(setProfile)
-        .catch(err => {
-          console.error('fetchProfile failed:', err);
-        });
-    }
+    setLoading(true);
+    fetchProfile(user_id)
+      .then(data => setProfile(data))
+      .catch(err => console.error('fetchProfile failed:', err))
+      .finally(() => setLoading(false));
   }, [user_id]);
 
-  const save = data => {
-    if (USE_STUB) {
-      // 스텁 모드: 상태 + localStorage 동시 갱신
-      const updated = { ...profile, ...data };
-      setProfile(updated);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-      console.log('[Profile Stub] saved', updated);
-      return Promise.resolve(updated);
-    }
-
-    // 실제 API 호출
-    return updateProfile(user_id, data).then(updated => {
-      setProfile(updated);
-      return updated;
-    });
+  const save = (data) => {
+    setLoading(true);
+    return updateProfile(user_id, data)
+      .then(updated => {
+        setProfile(updated);
+        return updated;
+      })
+      .finally(() => setLoading(false));
   };
 
-  return { profile, save };
+  return { profile, loading, save };
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,6 @@
+// src/pages/Login.jsx
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { jwtDecode } from 'jwt-decode';
 import { useAuth } from "../context/AuthContext";
 import { loginRequest } from "../api/auth";
 
@@ -8,7 +8,7 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const { login } = useAuth();
 
-  const [account, setAccount] = useState("");
+  const [account, setAccount]   = useState("");
   const [password, setPassword] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -19,23 +19,15 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      // 로그인 API 호출
+      // 로그인 API 호출 (stub 모드든 실제 모드든 loginRequest 내부에서 처리)
       const { access, refresh } = await loginRequest(account, password);
-
-      // 로컬 스토리지에 토큰 저장
-      localStorage.setItem("accessToken", access);
-      localStorage.setItem("refreshToken", refresh);
-
-      // decode 해서 user_id 추출
-      const { user_id } = jwtDecode(access);
-
-      // Context에 user_id로 저장
-      login({ user_id: user_id });
-
-      // 메인 페이지로 이동
+      // AuthContext.login 으로 토큰 저장 및 user_id 추출·상태 반영
+      login({ access, refresh });
+      // 로그인 후 메인 페이지로 이동
       navigate("/");
-    } catch {
-      setErrorMsg("계정 또는 비밀번호가 올바르지 않습니다.");
+    } catch (err) {
+      console.error(err);
+      setErrorMsg("아이디 또는 비밀번호가 올바르지 않습니다.");
       setIsLoading(false);
     }
   };
@@ -48,11 +40,8 @@ export default function LoginPage() {
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* ID 입력 */}
             <div>
-              <label
-                htmlFor="account"
-                className="block text-sm font-medium text-gray-700"
-              >
-                ID
+              <label htmlFor="account" className="block text-sm font-medium text-gray-700">
+                아이디
               </label>
               <input
                 id="account"
@@ -68,10 +57,7 @@ export default function LoginPage() {
 
             {/* 비밀번호 입력 */}
             <div>
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-gray-700"
-              >
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
                 비밀번호
               </label>
               <input
@@ -97,12 +83,11 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={isLoading}
-              className={`w-full py-2 rounded-lg font-semibold transition-colors
-                ${
-                  isLoading
-                    ? "bg-gray-400 text-white cursor-not-allowed"
-                    : "bg-black text-white hover:bg-gray-100 hover:text-black"
-                }`}
+              className={`w-full py-2 rounded-lg font-semibold transition-colors ${
+                isLoading
+                  ? "bg-gray-400 text-white cursor-not-allowed"
+                  : "bg-black text-white hover:bg-gray-100 hover:text-black"
+              }`}
             >
               {isLoading ? "로그인 중..." : "로그인"}
             </button>
@@ -110,10 +95,7 @@ export default function LoginPage() {
             {/* 회원가입 링크 */}
             <p className="text-center text-sm">
               아직 회원이 아니신가요?{" "}
-              <Link
-                to="/signup"
-                className="text-black font-medium hover:underline"
-              >
+              <Link to="/signup" className="text-black font-medium hover:underline">
                 회원가입
               </Link>
             </p>


### PR DESCRIPTION
- src/auth.js:
    - 테스트 상태면 로그인 시 mockapi 쪽 연결
    - 테스트 상태가 아니면 실제 backend와 연결
    - 불필요한 주석 코드 정리
- src/context/AuthContext.jsx & src/pages/Login.jsx:
    - 로직 관련 부분 Login.jsx에서 AuthContext.jsx로 추가 분리
- src/api/profile.js & src/hooks/useProfile.js
    - 테스트 상태면 mockapi의 현재 유저 정보 조회 - 기존 테스트는 local에 데이터 선언해두고 사용하는 식으로 했음 - 데이터 수정 시 mockapi에 수정 영향 가게 구현
    - 테스트 상태가 아니면 실제 backend와 연결