### PR TITLE
feat (HG-96): 결제 기능 개선 등

### DIFF
--- a/src/api/kakaopay.js
+++ b/src/api/kakaopay.js
@@ -1,16 +1,22 @@
+// src/api/kakaopay.js
 import axios from 'axios';
 
-// const SECRET_KEY = process.env.REACT_APP_KAKAO_SECRET_KEY;
+const SECRET_KEY = process.env.REACT_APP_KAKAO_SECRET_KEY;
 
 // ✅ 결제 준비 요청
 export async function requestKakaoPay(items, user) {
   const totalAmount = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
 
+  const itemName =
+    items.length === 1
+      ? items[0].name
+      : `${items[0].name} 외 ${items.length - 1}건`;
+
   const data = {
     cid: 'TC0ONETIME',
     partner_order_id: 'order1234',
     partner_user_id: user?.user_id || 'guest',
-    item_name: items[0]?.name || '테스트상품',
+    item_name: itemName || '테스트상품',
     quantity: items.length,
     total_amount: totalAmount,
     tax_free_amount: 0,
@@ -20,18 +26,12 @@ export async function requestKakaoPay(items, user) {
   };
 
   const headers = {
-    Authorization: `SECRET_KEY ${process.env.REACT_APP_KAKAO_SECRET_KEY}`,
+    Authorization: `SECRET_KEY ${SECRET_KEY}`,
     'Content-Type': 'application/json',      // ✅ JSON 형식
   };
 
-  try {
-    const response = await axios.post('/kakao/online/v1/payment/ready', data, { headers });
-    console.log('✅ 결제 준비 응답:', response.data);
-    return response.data; // next_redirect_pc_url, tid 등 포함
-  } catch (err) {
-    console.error('❌ 결제 준비 실패:', err.response?.data || err.message);
-    throw err;
-  }
+  const response = await axios.post('/kakao/online/v1/payment/ready', data, { headers });
+  return response.data;
 }
 
 // ✅ 결제 승인 요청
@@ -45,16 +45,10 @@ export async function approveKakaoPay({ tid, pg_token, user_id }) {
   };
 
   const headers = {
-    Authorization: `SECRET_KEY ${process.env.REACT_APP_KAKAO_SECRET_KEY}`,
+    Authorization: `SECRET_KEY ${SECRET_KEY}`,
     'Content-Type': 'application/json',
   };
 
-  try {
-    const response = await axios.post('/kakao/online/v1/payment/approve', data, { headers });
-    console.log('✅ 결제 승인 응답:', response.data);
-    return response.data;
-  } catch (err) {
-    console.error('❌ 결제 승인 실패:', err.response?.data || err.message);
-    throw err;
-  }
+  const response = await axios.post('/kakao/online/v1/payment/approve', data, { headers });
+  return response.data;
 }

--- a/src/api/orders.js
+++ b/src/api/orders.js
@@ -1,53 +1,62 @@
 // src/api/orders.js
 import api from './index';
+import axios from 'axios';
 
 const USE_STUB = process.env.REACT_APP_USE_STUB === 'true';
-
-// 스텁용 메모리
-let stub_orders = [
-  {
-    id:         123,
-    created_at: '2025-05-09',
-    items:      [
-      { name: '티셔츠', quantity: 1 },
-      { name: '청바지', quantity: 2 }
-    ],
-    total:      45000,
-    status:     'shipping'   // 배송중
-  },
-  {
-    id:         124,
-    created_at: '2025-05-08',
-    items:      [ { name: '스니커즈', quantity: 1 } ],
-    total:      75000,
-    status:     'delivered'  // 배송완료
-  }
-];
+const STUB_BASE_URL = 'https://6822d576b342dce8004f85a8.mockapi.io';
 
 /** GET /order/{user_id} */
 export function fetchOrders(user_id) {
   if (USE_STUB) {
-    return new Promise(res => setTimeout(() => res([...stub_orders]), 200));
+    return axios
+      .get(`${STUB_BASE_URL}/order`, { params: { user_id } })
+      .then(response => response.data);
   }
-  return api.get(`/order/${user_id}`).then(r => r.data);
+  return api
+    .get(`/order/${user_id}`)
+    .then(response => response.data);
 }
 
 /**
- * PATCH /order/{order_id}
+ * 주문 상태 업데이트
+ * PUT /order/{order_id}
  * 바디: { status: string }
  */
 export function updateOrderStatus(order_id, status) {
   if (USE_STUB) {
-    return new Promise(res => {
-      setTimeout(() => {
-        stub_orders = stub_orders.map(o =>
-          o.id === order_id ? { ...o, status } : o
-        );
-        res();
-      }, 200);
-    });
+    return axios
+      .put(`${STUB_BASE_URL}/order/${order_id}`, { status })
+      .then(response => response.data);
   }
   return api
     .put(`/order/${order_id}`, { status })
-    .then(r => r.data);
+    .then(response => response.data);
+}
+
+/**
+ * 주문 생성
+ * POST /order 또는 /orders
+ * @param {string}   user_id
+ * @param {Object[]} items          // [{ product_id, quantity, price }, …]
+ * @param {number}   total_price
+ * @param {boolean}  is_from_cart
+ * @param {string}   status         // 기본 'paid'
+ */
+export function createOrder({ user_id, items, total_price, is_from_cart, status = 'paid', }) {
+  const payload = {
+    user_id,
+    order_items: items.map(item => ({
+      product_id: item.product_id,
+      quantity: item.quantity,
+      price: item.price,
+    })),
+    total_price,
+    is_from_cart,
+    status,
+  };
+
+  if (USE_STUB) {
+    return axios.post(`${STUB_BASE_URL}/order`, payload).then(r => r.data);
+  }
+  return api.post('/order', payload).then(r => r.data);
 }

--- a/src/api/product.js
+++ b/src/api/product.js
@@ -1,15 +1,21 @@
+import api from './index';
 import axios from "axios";
 
-const PRODUCT_BASE_URL = 'https://6822bd75b342dce8004f37fb.mockapi.io';
+const STUB_BASE_URL = 'https://6822bd75b342dce8004f37fb.mockapi.io';
+const USE_STUB = process.env.REACT_APP_USE_STUB === 'true';
 
 // 상품 리스트 전체 조회
 export const fetchProducts = async () => {
-  const response = await axios.get(`${PRODUCT_BASE_URL}/product`);
-  return response.data;
+  if (USE_STUB) {
+    return axios.get(`${STUB_BASE_URL}/product`).then(r => r.data);
+  }
+  return api.get(`/product`).then(r => r.data);
 };
 
 // 브랜드 전체 조회
 export const fetchBrands = async () => {
-  const response = await axios.get(`${PRODUCT_BASE_URL}/brand`);
-  return response.data;
+  if (USE_STUB) {
+    return axios.get(`${STUB_BASE_URL}/brand`);
+  }
+  return api.get(`/brand`).then(r => r.data);
 };

--- a/src/components/CartSummary.jsx
+++ b/src/components/CartSummary.jsx
@@ -1,87 +1,3 @@
-// import React from 'react';
-// import { useNavigate } from 'react-router-dom';
-// import { useAnalytics } from '../hooks/useAnalytics';
-
-// export default function CartSummary({ items, loading }) {
-//   const navigate = useNavigate();
-//   const { track } = useAnalytics();
-
-//   // 금액 계산: JSON 데이터 기반으로
-//   const subtotal = items.reduce(
-//     (sum, i) => sum + (i.price) * i.quantity,
-//     0
-//   );
-
-//   const discount = items.reduce(
-//     (sum, i) =>
-//       sum + ((i.price ?? 0) - (i.discounted_price ?? i.price)) * i.quantity,
-//     0
-//   );
-
-//   const shipping = subtotal >= 30000 ? 0 : 3000;
-//   const total = subtotal + shipping - discount;
-
-//   const rate =
-//     discount > 0
-//       ? Math.floor((discount / (subtotal + discount)) * 100)
-//       : 0;
-
-//   const handleCheckout = () => {
-//     track('checkout', {
-//       product_ids: items.map(i => i.product_id),
-//       total,
-//     });
-
-//     navigate('/checkout', {
-//       state: {
-//         items,
-//       },
-//     });
-//   };
-
-//   return (
-//     <div className="p-4 border rounded-lg bg-white mt-6 text-sm leading-relaxed">
-//       <h2 className="font-semibold mb-4 text-base">구매 금액</h2>
-
-//       <div className="flex justify-between mb-2">
-//         <span>상품 금액</span>
-//         <span>{subtotal.toLocaleString()}원</span>
-//       </div>
-
-//       <div className="flex justify-between mb-2">
-//         <span>할인 금액</span>
-//         <span className="text-blue-600">-{discount.toLocaleString()}원</span>
-//       </div>
-
-//       <div className="flex justify-between mb-4">
-//         <span>배송비</span>
-//         <span>{shipping === 0 ? '무료배송' : `${shipping.toLocaleString()}원`}</span>
-//       </div>
-
-//       <div className="flex justify-between items-center mt-4 border-t pt-4 font-semibold text-lg">
-//         <span className="text-gray-600">총 결제 금액</span>
-//         <span>
-//           <span className="text-red-500 text-sm mr-1">
-//             {rate > 0 ? `${rate}%` : ''}
-//           </span>
-//           {total.toLocaleString()}원
-//         </span>
-//       </div>
-
-//       <button
-//         onClick={handleCheckout}
-//         disabled={loading || items.length === 0}
-//         className={`w-full py-2 rounded-lg text-white font-medium ${
-//           items.length
-//             ? 'bg-blue-600 hover:bg-blue-700'
-//             : 'bg-gray-400 cursor-not-allowed'
-//         }`}
-//       >
-//         결제하기
-//       </button>
-//     </div>
-//   );
-// }
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAnalytics } from '../hooks/useAnalytics';
@@ -110,6 +26,7 @@ export default function CartSummary({ items, loading }) {
     navigate('/checkout', {
       state: {
         items,
+        is_from_cart: true,
       },
     });
   };

--- a/src/hooks/useOrders.js
+++ b/src/hooks/useOrders.js
@@ -5,22 +5,32 @@ import { fetchOrders, updateOrderStatus } from '../api/orders';
 
 export function useOrders() {
   const { user } = useAuth();
-  const user_id   = user?.user_id;
+  const user_id = user?.user_id;
 
   const [orders, setOrders] = useState([]);
+
   const reload = useCallback(() => {
     if (!user_id) return;
-    fetchOrders(user_id).then(setOrders).catch(console.error);
+    fetchOrders(user_id)
+      .then(raw => {
+        // API 리턴값을 UI가 쓰기 좋은 형태로 매핑
+        const mapped = raw.map(o => ({
+          ...o,
+          items: o.order_items || [],             // order_items → items
+          total: o.total_price != null ? o.total_price : 0, // total_price → total
+        }));
+        setOrders(mapped);
+      })
+      .catch(console.error);
   }, [user_id]);
 
   useEffect(() => {
     reload();
   }, [reload]);
 
-  /** 주문 환불(→status='refunded') */
-  const refund = order_id =>
-    updateOrderStatus(order_id, 'refunded')
-      .then(() => reload());
+  /** 주문 환불(→status='cancelled') */
+  const cancel = order_id =>
+    updateOrderStatus(order_id, 'cancelled').then(() => reload());
 
-  return { orders, refund };
+  return { orders, cancel };
 }

--- a/src/pages/Product.jsx
+++ b/src/pages/Product.jsx
@@ -138,8 +138,9 @@ function Product() {
             img_url: product.img_url,
             quantity,
             discount: discount,
-          }
-        ]
+          },
+        ],
+        is_from_cart: false,
       }
     });
   };

--- a/src/pages/admin/products/productApi.js
+++ b/src/pages/admin/products/productApi.js
@@ -1,29 +1,55 @@
 // src/pages/admin/products/productApi.js
 import api from '../../../api/index';
+import axios from 'axios';
+
+const STUB_BASE_URL = 'https://6822bd75b342dce8004f37fb.mockapi.io';
+const USE_STUB = process.env.REACT_APP_USE_STUB === 'true';
+
+export const fetchProducts = async () => {
+  if (USE_STUB) {
+    return axios.get(`${STUB_BASE_URL}/product`).then(r => r.data);
+  }
+  return api.get(`/product`).then(r => r.data);
+};
 /**
  * 관리자용 Product(CRUD) API
  * 일단 admin이 아닌, 일반 post, put, delete로 하고 추후 수정
  */
 export const getProducts = async () => {
+  if (USE_STUB) {
+    return axios.get(`${STUB_BASE_URL}/product`).then(r => r.data);
+  }
   const res = await api.get('/product');
   return res.data;
 };
 
 export const getProduct = async (id) => {
+  if (USE_STUB) {
+    return axios.get(`${STUB_BASE_URL}/product/${id}`).then(r => r.data);
+  }
   const res = await api.get(`/product/${id}`);
   return res.data;
 };
 
 export const createProduct = async (product) => {
+  if (USE_STUB) {
+    return axios.post(`${STUB_BASE_URL}/product`, product).then(r => r.data);
+  }
   const res = await api.post('/product', product);
   return res.data;
 };
 
 export const updateProduct = async (id, product) => {
+  if (USE_STUB) {
+    return axios.put(`${STUB_BASE_URL}/product/${id}`, product).then(r => r.data);
+  }
   const res = await api.put(`/product/${id}`, product);
   return res.data;
 };
 
 export const deleteProduct = async (id) => {
+  if (USE_STUB) {
+    await axios.delete(`${STUB_BASE_URL}/product/${id}`);
+  }
   await api.delete(`/product/${id}`);
 };

--- a/src/pages/mypage/Orders.jsx
+++ b/src/pages/mypage/Orders.jsx
@@ -5,13 +5,14 @@ import { useOrders } from '../../hooks/useOrders';
 
 // status 코드 → 레이블 매핑
 const STATUS_LABEL = {
+  paid:      '결제완료',
   shipping:  '배송중',
-  delivered: '배송완료',
-  refunded:  '환불완료'
+  shipped:   '배송완료',
+  cancelled: '환불완료'
 };
 
 export default function OrdersPage() {
-  const { orders, refund } = useOrders();
+  const { orders, cancel } = useOrders();
 
   return (
     <main className="max-w-3xl mx-auto px-4 py-8">
@@ -54,10 +55,10 @@ export default function OrdersPage() {
               {/* 환불 버튼 */}
               <div className="text-right">
                 <button
-                  onClick={() => refund(o.id)}
-                  disabled={o.status === 'refunded'}
+                  onClick={() => cancel(o.id)}
+                  disabled={o.status === 'cancelled'}
                   className={`px-4 py-1 text-sm rounded
-                    ${o.status === 'refunded'
+                    ${o.status === 'cancelled'
                       ? 'bg-gray-300 text-gray-600 cursor-not-allowed'
                       : 'bg-red-600 text-white hover:bg-red-700'}`}
                 >

--- a/src/pages/pay/PayApprove.jsx
+++ b/src/pages/pay/PayApprove.jsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useRef } from 'react';
+// src/pages/pay/payApprove.jsx
+import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { approveKakaoPay } from '../../api/kakaopay'; // 경로는 프로젝트에 맞게 수정
+import { createOrder } from '../../api/orders';
 
-function PayApprove() {
+export default function PayApprove() {
   const location = useLocation();
   const navigate = useNavigate();
   const executedRef = useRef(false); // ✅ 실행 여부 추적
@@ -11,30 +13,31 @@ function PayApprove() {
     if (executedRef.current) return; // 이미 실행했으면 skip
     executedRef.current = true;
 
-    const urlParams = new URLSearchParams(location.search);
-    const pgToken = urlParams.get('pg_token');
+    const url_params = new URLSearchParams(location.search);
+    const pg_token = url_params.get('pg_token');
     const tid = sessionStorage.getItem('kakao_tid');
-    const user_id = sessionStorage.getItem('kakao_user_id') || 'guest';
+    const user_id = sessionStorage.getItem('kakao_user_id');
 
-    if (!pgToken || !tid) {
-      console.error('필수 값 누락 (pg_token 또는 tid)');
-      return;
-    }
+    // 주문 정보 불러오기
+    const order_items = JSON.parse(sessionStorage.getItem('order_items') || '[]');
+    const total_price = Number(sessionStorage.getItem('total_price')) || 0;
+    const is_from_cart = sessionStorage.getItem('is_from_cart') === 'true';
 
-    approveKakaoPay({ tid, pg_token: pgToken, user_id })
-      .then((res) => {
-        console.log('✅ 결제 승인 성공:', res);
-        navigate('/pay/approve');
-        alert('결제가 완료되었습니다.'); // ✅ 알림창
-        navigate('/mypage/orders'); // ✅ 알림 확인 후 이동
+    if (!pg_token || !tid) return navigate('/pay/fail');
+
+    approveKakaoPay({ tid, pg_token, user_id })
+      .then(async () => {
+        await createOrder({
+          user_id,
+          items: order_items,
+          total_price,
+          is_from_cart,
+          status: 'paid',
+        });
+        navigate('/mypage/orders');
       })
-      .catch((err) => {
-        console.error('❌ 결제 승인 실패:', err);
-        navigate('/pay/fail');
-      });
+      .catch(() => navigate('/pay/fail'));
   }, [location, navigate]);
 
   return null; // ✅ 메시지 안 보이게 처리
 }
-
-export default PayApprove;


### PR DESCRIPTION
- 카카오페이 프론트에서 수행
- /order로 주문 내역 데이터 전송
- 장바구니, 상품 상세 페이지 중 주문 발생 페이지 플래그 추가
    - 이를 토대로 장바구니 데이터 초기화 여부 결정
- 해당 데이터 마이페이지-주문 내역 페이지에서 조회 및 수정 가능
- 관리자 페이지에서 mockapi의 상품 목록 조회 기능 구현